### PR TITLE
보험명:날짜 를 키로 similarirty search 가능하게 수정

### DIFF
--- a/code/pages/00_Chat.py
+++ b/code/pages/00_Chat.py
@@ -13,9 +13,10 @@ def clear_chat_data():
     st.session_state['source_documents'] = []    
 
 def chage_synonym(question):
-    for idx, row in synonym_df.iterrows():
-        question = re.sub("|".join(row.synonymList), row.title, question)
-    return question   
+    return question
+    # for idx, row in synonym_df.iterrows():
+    #     question = re.sub("|".join(row.synonymList), row.title, question)
+    # return question   
 
 
 # Initialize chat history
@@ -30,8 +31,8 @@ llm_helper = LLMHelper()
 
 # load synonym data
 synonym_df = llm_helper.vector_store.get_synonym_results()
-
-# Chat 
+st.text(synonym_df)
+# Chat
 st.text_input("You: ", placeholder="type your question", key="input", on_change=clear_text_input)
 clear_chat = st.button("Clear chat", key="clear_chat", on_click=clear_chat_data)
 

--- a/code/test.py
+++ b/code/test.py
@@ -1,26 +1,30 @@
 import streamlit as st
 import os
-import traceback
 from utilities.helper import LLMHelper
 
 llm_helper = LLMHelper()
 
 
-llm_helper.vector_store.add_synonym_result(
-    "커맨드 테스트",
-    writer="원준호",
-    regdate="20230605",
-    title="커맨드 테스트",
-    synonymList=["command test", "커맨드 태스트"]
+import openai
+
+response = openai.Completion.create(
+  model="text-davinci-003",
+  prompt= ['Content: 실료,입원제비용,입원수술비,비급여병실료 | |보장대상의료비 | 실제부담액보상제외금액* * 제3관회사가보장하지않는사항에따른금액및비 급여병실료중회사가보장하지않는금액 | |도수치료 | 치료자가손(정형용교정장치장비등의도움을받는경 우를포함합니다)을이용해서환자의근골격계통(관절,근 육,연부조직,림프절등)의기능개선및통증감소를위 하여실시하는치료행위 * 의사또는의사의지도하에물리\nSource: [https://newklfnwdkogbewiostr.blob.core.windows.net/documents/%28%EB%AC%B4%29%EA%B5%90%EB%B3%B4%EC%8B%A4%EC%86%90%EC%9D%98%EB%A3%8C%EB%B9%84%EB%B3%B4%ED%97%98%28%EA%B0%B1%EC%8B%A0%ED%98%95%293_20230601.pdf.txt](https://newklfnwdkogbewiostr.blob.core.windows.net/documents/%28%EB%AC%B4%29%EA%B5%90%EB%B3%B4%EC%8B%A4%EC%86%90%EC%9D%98%EB%A3%8C%EB%B9%84%EB%B3%B4%ED%97%98%28%EA%B0%B1%EC%8B%A0%ED%98%95%293_20230601.pdf.txt_SAS_TOKEN_PLACEHOLDER_)\n\nContent: 실료,입원제비용,입원수술비,비급여병실료 | |보장대상의료비 | 실제부담액보상제외금액* * 제3관회사가보장하지않는사항에따른금액및비 급여병실료중회사가보장하지않는금액 | |도수치료 | 치료자가손(정형용교정장치장비등의도움을받는경 우를포함합니다)을이용해서환자의근골격계통(관절,근 육,연부조직,림프절등)의기능개선및통증감소를위 하여실시하는치료행위 * 의사또는의사의지도하에물리\nSource: [https://newklfnwdkogbewiostr.blob.core.windows.net/documents/%28%EB%AC%B4%29%EA%B5%90%EB%B3%B4%EC%8B%A4%EC%86%90%EC%9D%98%EB%A3%8C%EB%B9%84%EB%B3%B4%ED%97%98%28%EA%B0%B1%EC%8B%A0%ED%98%95%293_20210331.pdf.txt](https://newklfnwdkogbewiostr.blob.core.windows.net/documents/%28%EB%AC%B4%29%EA%B5%90%EB%B3%B4%EC%8B%A4%EC%86%90%EC%9D%98%EB%A3%8C%EB%B9%84%EB%B3%B4%ED%97%98%28%EA%B0%B1%EC%8B%A0%ED%98%95%293_20210331.pdf.txt_SAS_TOKEN_PLACEHOLDER_)\n\nContent: 실료,입원제비용,입원수술비,비급여병실료 | |보장대상의료비 | 실제부담액보상제외금액* * 제3관회사가보장하지않는사항에따른금액및비 급여병실료중회사가보장하지않는금액 | |도수치료 | 치료자가손(정형용교정장치장비등의도움을받는경 우를포함합니다)을이용해서환자의근골격계통(관절,근 육,연부조직,림프절등)의기능개선및통증감소를위 하여실시하는치료행위 * 의사또는의사의지도하에물리\nSource: [https://newklfnwdkogbewiostr.blob.core.windows.net/documents/%28%EB%AC%B4%29%EA%B5%90%EB%B3%B4%EC%8B%A4%EC%86%90%EC%9D%98%EB%A3%8C%EB%B9%84%EB%B3%B4%ED%97%98%28%EA%B0%B1%EC%8B%A0%ED%98%95%293_20230331.pdf.txt](https://newklfnwdkogbewiostr.blob.core.windows.net/documents/%28%EB%AC%B4%29%EA%B5%90%EB%B3%B4%EC%8B%A4%EC%86%90%EC%9D%98%EB%A3%8C%EB%B9%84%EB%B3%B4%ED%97%98%28%EA%B0%B1%EC%8B%A0%ED%98%95%293_20230331.pdf.txt_SAS_TOKEN_PLACEHOLDER_)\n\nContent: 실료,입원제비용,입원수술비,비급여병실료 | |보장대상의료비 | 실제부담액보상제외금액* * 제3관회사가보장하지않는사항에따른금액및비 급여병실료중회사가보장하지않는금액 | |도수치료 | 치료자가손(정형용교정장치장비등의도움을받는경 우를포함합니다)을이용해서환자의근골격계통(관절,근 육,연부조직,림프절등)의기능개선및통증감소를위 하여실시하는치료행위 * 의사또는의사의지도하에물리\nSource: [https://newklfnwdkogbewiostr.blob.core.windows.net/documents/%28%EB%AC%B4%29%EA%B5%90%EB%B3%B4%EC%8B%A4%EC%86%90%EC%9D%98%EB%A3%8C%EB%B9%84%EB%B3%B4%ED%97%98%28%EA%B0%B1%EC%8B%A0%ED%98%95%293_20230601.pdf.txt](https://newklfnwdkogbewiostr.blob.core.windows.net/documents/%28%EB%AC%B4%29%EA%B5%90%EB%B3%B4%EC%8B%A4%EC%86%90%EC%9D%98%EB%A3%8C%EB%B9%84%EB%B3%B4%ED%97%98%28%EA%B0%B1%EC%8B%A0%ED%98%95%293_20230601.pdf.txt_SAS_TOKEN_PLACEHOLDER_)\nPlease reply to the question using only the information present in the text above. \nInclude references to the sources you used to create the answer if those are relevant ("SOURCES"). Answer naturally, like a person talks\nQuestion: 도수치료 치료비 알려줘\nAnswer:'], 
+  engine= 'TEST', 
+  temperature= 0.0, 
+  max_tokens= 842, 
+  top_p= 1, 
+  frequency_penalty= 0, 
+  presence_penalty= 0, 
+  n= 1, 
+  best_of= 1, 
+  request_timeout= None, 
+  logit_bias= {}
 )
 
-synonym_df = llm_helper.vector_store.get_synonym_results()
 
-import re
-sent = "안녕 command test 호호"
-for idx, row in synonym_df.iterrows():
-    sent = re.sub("|".join(row.synonymList), row.title, sent)
-
-print(sent)
+print(response['choices'][0]['text'].encode().decode())
 
 
+
+#\ub3c4\uc218\uce58\ub8cc\ub294 \uce58\ub8cc\uc790\uac00 \uc190(\uc815\ud615\uc6a9 \uad50\uc815 \uc7a5\uce58 \uc7a5\ube44 \ub4f1\uc758 \ub3c4\uc6c0\uc744 \ubc1b\ub294 \uacbd\uc6b0\ub97c \ud3ec\ud568\ud569\ub2c8\ub2e4)\uc744 \uc774\uc6a9\ud574\uc11c \ud658\uc790\uc758 \uadfc\uace8\uaca9 \uacc4\ud1b5(\uad00\uc808, \uadfc\uc721, \uc5f0\ubd80 \uc870\uc9c1, \ub9bc\ud504\uc808 \ub4f1)\uc758 \uae30\ub2a5 \uac1c\uc120 \ubc0f \ud1b5\uc99d \uac10\uc18c\ub97c \uc704\ud574 \uc2e4\uc2dc\ud558\ub294 \uce58\ub8cc \ud589\uc704\ub97c \ub9d0\ud569\ub2c8\ub2e4. \uc758\uc0ac\ub098 \uc758\uc0ac\uc758 \uc9c0\ub3c4\ud558\uc5d0 \ubb3c\ub9ac\ud559\uc801 \uce58\ub8cc\ub97c \uc2e4\uc2dc\ud569\ub2c8\ub2e4.\nSOURCES: https://newklfnwdkogbewiostr.blob.core.windows.net/documents/%28%EB%AC%B4%29%EA%B5%90%EB%B3%B4%EC%8B%A4%EC%86%90%EC%9D%98%EB%A3%8C%EB%B9%84%EB%B3%B4%ED%97%98%28%EA%B0%B1%EC%8B%A0%ED%98%95%293_20230601.pdf.txt"

--- a/code/test_embed.py
+++ b/code/test_embed.py
@@ -1,0 +1,68 @@
+import streamlit as st
+import os
+from utilities.helper import LLMHelper
+import numpy as np
+
+llm_helper = LLMHelper()
+
+
+
+# 11111111111111111111111111111111111111111111
+# 보험명 들어오면, 가장 유사한 보험명 뽑아내고?? 년도는?
+
+
+# insurance:8546e2663fa3cd3f0e0ddf2c30de19a0be538470:20210331
+result = llm_helper.vector_store.similarity_search_with_score_insurance("보험", "*", index_name="insurance-index", k=1000)
+print(result)
+
+
+exit()
+
+# 2222222222222222222222222222222222222222
+# 질문 들어오면, 임베딩 벡터들과 비교해 4개의 본문 찾아내는 부분.
+# "*"부분에 hash(상품명:일자) 값을 넣으면 검색됨.
+# result = llm_helper.vector_store.similarity_search("요실금 얼마야",  "f6707e308f4e88764ed7404a2a42964e80a8d01c", k=1000)
+# # doc:embeddings:f6707e308f4e88764ed7404a2a42964e80a8d01c:17
+# print(len(result))
+
+exit()
+
+
+# 33333333333333333333333333333333333333333333333333
+# similarity search 할때, query 테스트 부분.
+from typing import Any, Callable, Dict, Iterable, List, Mapping, Optional, Tuple
+from redis.commands.search.query import Query
+
+embedding = llm_helper.vector_store.embedding_function("요실금 얼마야")
+
+# Prepare the Query
+return_fields = ["metadata", "content", "vector_score"]
+vector_field = "content_vector"
+hybrid_fields = "f6707e308f4e88764ed7404a2a42964e80a8d01c"
+# f6707e308f4e88764ed7404a2a42964e80a8d01c
+base_query = (
+    f"{hybrid_fields}=>[KNN 1000 @{vector_field} $vector AS vector_score]"
+    # f"{hybrid_fields}=>[KNN {k} @{vector_field} $vector AS vector_score]"
+)
+redis_query = (
+    Query(base_query)
+    .return_fields(*return_fields)
+    .sort_by("vector_score")
+    # .paging(0, k)
+    .dialect(2)
+)
+params_dict: Mapping[str, str] = {
+    "vector": np.array(embedding)  # type: ignore
+    .astype(dtype=np.float32)
+    .tobytes()
+}
+
+# perform vector search
+results = llm_helper.vector_store.client.ft("embeddings").search(redis_query, params_dict)
+# doc:embeddings:f6707e308f4e88764ed7404a2a42964e80a8d01c:111
+
+print(results.total)
+
+# print(llm_helper.vector_store.get_insurance_info())
+
+exit()

--- a/code/utilities/customprompt.py
+++ b/code/utilities/customprompt.py
@@ -3,6 +3,7 @@ from langchain.prompts import PromptTemplate
 
 template = """{summaries}
 Please reply to the question using only the information present in the text above. 
+Based on the text above, speak as grammatically as possible like a call center employee
 Include references to the sources you used to create the answer if those are relevant ("SOURCES"). 
 If you can't find it, reply politely that the information is not in the knowledge base.
 Question: {question}
@@ -14,5 +15,3 @@ EXAMPLE_PROMPT = PromptTemplate(
     template="Content: {page_content}\nSource: {source}",
     input_variables=["page_content", "source"],
 )
-
-


### PR DESCRIPTION
1. hash key 방식 변경
embdding 벡터는 "doc:embeddings:hash(보험명:날짜):숫자" 형태로 변경
보험정보는 "insurance:hash(보험명):날짜" 형태로 저장.

2. "보험명:날짜" 를 hash key로 similarirty search 가능하게 수정.
특정 보험명, 날짜에 나온 pdf 파일에서만 본문 추출가능. 

3. 사용자가 입력한 보험명을 기반으로 가장 유사한 보험명을 내뱉는 코드 작성.
날짜 조회는 어떻게 할지 생각해야함.
보험명만으로 조회하면... 개정날짜 데이터 많으면 그 데이터들만 top 4로 나올듯 <<